### PR TITLE
Fix for contrib messages in Django 1.4

### DIFF
--- a/pagelets/views.py
+++ b/pagelets/views.py
@@ -140,7 +140,7 @@ def remove_pagelet(
     
     if request.method == 'POST':
         pagelet.delete()
-        messages.info('Pagelet successfully deleted.')
+        messages.info(request, 'Pagelet successfully deleted.')
         return HttpResponseRedirect(redirect_to)
     return render_to_response(
         template,


### PR DESCRIPTION
The commits in this pull request represent a simple two line change that moves the "remove pagelet" view's use of django contrib messages over to the new API, since the old one is deprecated in Django 1.4.
