### PR TITLE
[WIP] Support for custom types of pagelets defined by a project to appear in

### DIFF
--- a/pagelets/conf.py
+++ b/pagelets/conf.py
@@ -40,3 +40,8 @@ if hasattr(settings, 'PAGELET_TEMPLATE_TAGS'):
 AUTO_LOAD_TEMPLATE_TAGS = '{%% load %s %%}' % ' '.join(tags)
 
 BASE_TEMPLATES = getattr(settings, 'PAGELET_BASE_TEMPLATES', [])
+
+PAGELET_TYPES = list(getattr(settings, 'PAGELET_ADDITIONAL_PAGELET_TYPES', ())) + [
+    'pagelets.InlinePagelet',
+    'pagelets.SharedPagelet',
+]

--- a/pagelets/models.py
+++ b/pagelets/models.py
@@ -112,15 +112,17 @@ class Page(PageletBase):
 
     tags = TaggableManager()
 
-    def get_area_pagelets(self, area_slug, with_shared=True):
+    def get_area_pagelets(self, area_slug):
         """
         Combines and sorts the inline and shared pagelets for a given content
         area.  Pagelets without an order are given 0, so they show up
         in the middle.
         """
-        pagelets = list(self.inline_pagelets.filter(area=area_slug))
-        if with_shared:
-            pagelets.extend(self.shared_pagelets.filter(area=area_slug))
+
+        pagelets = []
+        for pagelet_type in conf.PAGELET_TYPES:
+            pagelet_model = models.get_model(pagelet_type)
+            pagelets.extend( pagelet_model.objects.filter(page=self).filter(area=area_slug) )
         pagelets.sort(key=lambda a: a.order or 0)
         return pagelets
 

--- a/pagelets/templatetags/pagelet_tags.py
+++ b/pagelets/templatetags/pagelet_tags.py
@@ -37,7 +37,7 @@ def render_pagelet(context, pagelet):
     if pagelet:
         # add the slug separately because we need it in the template even
         # if this pagelet doesn't exist
-        context['pagelet_slug'] = pagelet.slug
+        context['pagelet_slug'] = getattr(pagelet, 'slug', None)
         context['page'] = parent_context.get('page', None)
         pagelet.rendered_content = pagelet.render(context)
     context['pagelet'] = pagelet

--- a/pagelets/views.py
+++ b/pagelets/views.py
@@ -122,6 +122,25 @@ def edit_pagelet(
                     )
                     pagelet_preview = form.save(commit=False, user=request.user)
         else:
+            # For non-Inline non-Shared pagelets they can be of a type that can't be edited in the
+            # front-end. Look for the form, if one is provided. If not, redirect to the admin change
+            # url for that object.
+
+            # Look at all the extension related names
+            # if present on this object, find the model
+            # look at the settings did it define a form?
+            # use that form if it is there
+            # otherwise, redirec to the change URL
+
+            for pagelet_type in conf.PAGELET_TYPES:
+                pagelet_model = models.get_model(pagelet_type)
+                try:
+                    pagelet = pagelet_model.objects.get(pk=pagelet.pk)
+                except pagelet_model.DoesNotExist:
+                    continue
+                else:
+                    redirect("admin:%s_change" % (pagelet_type.replace('.').lower(),), (pagelet.pk,))
+
             form = PageletForm(instance=pagelet)
 
         context = {


### PR DESCRIPTION
pages.

Custom pagelet types inherit from PageletBase and define their own
render(). They are registered in settings with
PAGELET_ADDITIONAL_PAGELET_TYPES, a list of app.model strings.

Custom types have an order and area of the page to render in, but they
do not have a slug, unless they decide to define one. If they appear
with an edit link, the link will redirect to the admin.
