### PR TITLE
Django 1.10 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = pagelets
+omit = */tests*,*/migrations/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build/*
 attachments/
 dist/
 .tox
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+
+python:
+  - "2.7"
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2014, Caktus Consulting Group, LLC
+Copyright (c) 2008-2017, Caktus Consulting Group, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -13,42 +13,21 @@ Features
 - Different pagelet content types including HTML and Markdown
 - An integrated WYSIWYG editor (`WYMeditor <http://www.wymeditor.org/>`_) which can be selectively enabled/disabled
 
-Changes in 0.10.0
------------------
-
-Pagelets 0.10.0 includes a number of changes to support Django 1.7 and the new migration framework.
-You should be aware of these changes if you are upgrading from the latest 0.9.x release of pagelets.
-If you are using pagelets in a project for the first time with version 0.10.0 or newer, you should
-not need to worry about any of these changes.
-
-Pagelets no longer users django-tagging, which did not support Django 1.7 migrations and is no
-longer maintained. We now use django-taggit. At the moment there is no migration to move tags from
-django-tagging to django-taggit.
-
 Required Dependencies
 ---------------------
 
-- Django 1.7
-- Python 2.7 or 3.3
+- Django >= 1.8
+- A Python version supported by your chosen Django version
 - Django admin site
 - django-taggit 0.12.1 or greater
 - django-selectable 0.9.0 or greater
-- The `django.core.context_processors.request` context processor
+- The `django.template.context_processors.request` context processor
 
 Optional Dependencies
 ---------------------
 
 - `jQuery 1.7 <http://jquery.com>`_
 - `WYMeditor <http://www.wymeditor.org/>`_ (included in pagelets media)
-
-Support for Django 1.4 through 1.6
-----------------------------------
-
-If you require support for a Django release before 1.7, you can use a release from the 0.9
-line of Pagelets, which supports Django 1.3, 1.4, 1.5, and 1.6. This release is also compatible
-with Python 3.3 for appropriate Django versions. At this time we will continue to support security
-updates to this version of Pagelets.
-
 
 Installation and Setup
 ----------------------
@@ -57,33 +36,41 @@ Installation and Setup
 
     pip install django-pagelets
 
-#. Add `pagelets` to INSTALLED_APPS in settings.py and run syncdb::
+#. Add `pagelets`, `selectable` and `taggit` to INSTALLED_APPS in settings.py and run migrate::
 
         INSTALLED_APPS = (
             ...,
             'pagelets',
+            'selectable',
+            'taggit'
             ...
         )
 
-#. Add `django.core.context_processors.request` to TEMPLATE_CONTEXT_PROCESSORS::
+#. Make sure `django.template.context_processors.request` is loaded and that you have a template
+   directory with a "base.html" template in it::
 
-    TEMPLATE_CONTEXT_PROCESSORS = (
-        "django.contrib.auth.context_processors.auth",
-        "django.core.context_processors.debug",
-        "django.core.context_processors.i18n",
-        "django.core.context_processors.media",
-        "django.core.context_processors.static",
-        "django.contrib.messages.context_processors.messages",
-        "django.core.context_processors.request", # <----
-    )
+
+     TEMPLATES=[
+         {
+             ...
+             'DIRS': ['/home/user/projects/myproject/templates'], # <- should have 'base.html' inside
+             ...
+             'OPTIONS': {
+                 'context_processors': [
+                     ...
+                     'django.template.context_processors.request',
+                 ]
+             },
+         },
+     ],
 
 #. Add the pagelets URLs to urls.py, e.g.::
 
-    urlpatterns += patterns('',
+    urlpatterns += [
         url(r'^selectable/', include('selectable.urls')),
         url(r'^pagelets-management/', include('pagelets.urls.management')),
         url(r'^', include('pagelets.urls.content')),
-    )
+    ]
 
 #. Visit the admin site, add and save a new page, and click the View on site link.  If everything is setup correctly, you should be able to see and edit the content you just added.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'django-pagelets'
-copyright = u'2010-2012, Caktus Consulting Group'
+copyright = u'2010-2017, Caktus Consulting Group'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pagelets/__init__.py
+++ b/pagelets/__init__.py
@@ -1,2 +1,2 @@
-version_info = (0, 10, 0)
+version_info = (1, 0, 0)
 __version__ = ".".join(map(str, version_info))

--- a/pagelets/admin.py
+++ b/pagelets/admin.py
@@ -1,7 +1,6 @@
 from django.contrib import admin
 from django.conf import settings
 from django.utils.html import strip_tags
-from django import forms
 
 from pagelets.forms import PageForm, InlinePageletForm, SharedPageletForm, PageletForm
 from pagelets.utils import truncate_html_words
@@ -115,6 +114,8 @@ class PageAdmin(admin.ModelAdmin):
             pagelet.modified_by = request.user
             pagelet.save()
         formset.save_m2m()
+
+
 admin.site.register(pagelets.Page, PageAdmin)
 
 
@@ -148,4 +149,6 @@ class PageletAdmin(admin.ModelAdmin):
             obj.created_by = request.user
             obj.modified_by = request.user
         obj.save()
+
+
 admin.site.register(pagelets.Pagelet, PageletAdmin)

--- a/pagelets/forms.py
+++ b/pagelets/forms.py
@@ -130,11 +130,11 @@ class PageForm(forms.ModelForm):
                                     required=False)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(PageForm, self).__init__(*args, **kwargs)
         if self.instance and self.instance.pk:
             self.initial['tags'] = self.instance.tags.all().values_list('pk', flat=True)
 
     def save(self, *args, **kwargs):
-        ret = super().save(*args, **kwargs)
+        ret = super(PageForm, self).save(*args, **kwargs)
         ret._pending_tags = set(tag.name for tag in self.cleaned_data['tags'])
         return ret

--- a/pagelets/forms.py
+++ b/pagelets/forms.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
@@ -116,7 +115,6 @@ class UploadForm(forms.ModelForm):
         return instance
 
 
-
 class PageForm(forms.ModelForm):
     class Meta:
         model = Page
@@ -128,7 +126,8 @@ class PageForm(forms.ModelForm):
         required=False,
     )
     base_template = forms.CharField(widget=forms.Select(choices=conf.BASE_TEMPLATES),
-        initial=conf.BASE_TEMPLATE_DEFAULT)
+                                    initial=conf.BASE_TEMPLATE_DEFAULT,
+                                    required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pagelets/models.py
+++ b/pagelets/models.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.html import strip_tags
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.template import compile_string, TemplateSyntaxError, StringOrigin
+from django.template import Template, TemplateSyntaxError
 from django.utils.encoding import python_2_unicode_compatible
 
 from datetime import datetime
@@ -173,20 +173,7 @@ class Pagelet(PageletBase):
         # pagelets can automagically use pagelets templatetags
         # in order to remove boilerplate
         loaded_cms = conf.AUTO_LOAD_TEMPLATE_TAGS + self.content
-        """
-        skip the first portions of render_to_string() ( finding the template )
-         and go directly to compiling the template/pagelet
-        render_to_string abbreviated:
-                def render_to_string(template_name, dictionary=None, context_instance=None):
-                       t = select/get_template(template_name)
-                               template = get_template_from_string(source, origin, template_name)
-                                       return Template(source, origin, name)
-                       t.render(context_instance)
-
-        """
-        #XXX is this what the origin should be?
-        origin = StringOrigin('pagelet: %s' % self.slug)
-        compiled = compile_string(loaded_cms, origin).render(context)
+        compiled = Template(loaded_cms).render(context)
         try:
             if self.type in ('html', 'tinymce', 'wymeditor'):
                 html = compiled

--- a/pagelets/models.py
+++ b/pagelets/models.py
@@ -276,6 +276,7 @@ class SharedPagelet(PlacedPageletBase):
 
     def _get_slug(self):
         return self.pagelet.slug
+
     def _set_slug(self, slug):
         self.__pagelet_dirty = True
         self.pagelet.slug = slug
@@ -283,6 +284,7 @@ class SharedPagelet(PlacedPageletBase):
 
     def _get_css_classes(self):
         return self.pagelet.css_classes
+
     def _set_css_classes(self, css_classes):
         self.__pagelet_dirty = True
         self.pagelet.css_classes = css_classes
@@ -290,6 +292,7 @@ class SharedPagelet(PlacedPageletBase):
 
     def _get_type(self):
         return self.pagelet.type
+
     def _set_type(self, type):
         self.__pagelet_dirty = True
         self.pagelet.type = type
@@ -297,6 +300,7 @@ class SharedPagelet(PlacedPageletBase):
 
     def _get_content(self):
         return self.pagelet.content
+
     def _set_content(self, content):
         self.__pagelet_dirty = True
         self.pagelet.content = content

--- a/pagelets/templates/pagelets/_pagelink_ifexists.html
+++ b/pagelets/templates/pagelets/_pagelink_ifexists.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 {% if page %}
 <a href="{% url 'view_page' page.slug %}">{{ link_text }}</a>
 {% endif %}

--- a/pagelets/templates/pagelets/_render_content_area.html
+++ b/pagelets/templates/pagelets/_render_content_area.html
@@ -1,5 +1,4 @@
 {% load pagelet_tags %}
-{% load url from future %}
 
 {% for pagelet in pagelets %}
     {% render_pagelet pagelet %}

--- a/pagelets/templates/pagelets/_render_pagelet.html
+++ b/pagelets/templates/pagelets/_render_pagelet.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <div{% if pagelet %} id="pagelet-{{ pagelet.real.pk }}"{% endif %} class="pagelet{% if pagelet_slug %} {{ pagelet_slug }}{% endif %}{% if perms.pagelets.change_pagelet and include_links %} editable{% endif %}{% if pagelet.css_classes %} {{ pagelet.css_classes }}{% endif %}">
 	{% if include_links %}
 	{% if perms.pagelets.change_pagelet or perms.pagelets.delete_pagelet %}

--- a/pagelets/templates/pagelets/view_page.html
+++ b/pagelets/templates/pagelets/view_page.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load url from future %}
 {% load pagelet_tags %}
 
 {% block title %}{{ page.title }}{% endblock %}
@@ -23,7 +22,7 @@
         {% render_content_area page 'main' %}
 
         <div id='page-attachments'>
-        {% ifnotequal page.attachments.count 0 %}
+        {% if page.attachments.count != 0 %}
             <h2>Attachments</h2>
             <ul>
                 {% for attachment in page.attachments.all %}
@@ -43,7 +42,7 @@
             {% if perms.pagelets.add_pageattachment %}
                 <p><a href='{% url "add_attachment" page.slug %}'>Add attachment...</a></p>
             {% endif %}
-        {% endifnotequal %}
+        {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/pagelets/templatetags/pagelet_tags.py
+++ b/pagelets/templatetags/pagelet_tags.py
@@ -3,7 +3,6 @@ import re
 from django import template
 from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
-from django.template import RequestContext, Context
 
 from pagelets.models import Pagelet, Page
 
@@ -20,12 +19,6 @@ def render_pagelet(context, pagelet):
     """
     Renders the named pagelet in the calling template.
     """
-    # don't modify the parent context
-    parent_context = context
-    if 'request' in context:
-        context = RequestContext(parent_context['request'])
-    else:
-        context = Context()
     if isinstance(pagelet, basestring):
         # add the slug separately because we need it in the template even
         # if this pagelet doesn't exist
@@ -38,7 +31,7 @@ def render_pagelet(context, pagelet):
         # add the slug separately because we need it in the template even
         # if this pagelet doesn't exist
         context['pagelet_slug'] = pagelet.slug
-        context['page'] = parent_context.get('page', None)
+        context['page'] = context.get('page', None)
         pagelet.rendered_content = pagelet.render(context)
     context['pagelet'] = pagelet
     context['include_links'] = True
@@ -51,11 +44,6 @@ def render_content_area(context, page, content_area):
     """
     Renders the named content area of the given page in the calling template.
     """
-    # don't modify the parent context
-    if 'request' in context:
-        context = RequestContext(context['request'])
-    else:
-        context = Context()
     if isinstance(page, basestring):
         page = Page.objects.get(slug=page)
     context['page'] = page
@@ -69,11 +57,6 @@ def pagelink_ifexists(context, page, link_text):
     """
     Renders a link to the given page in the calling template.
     """
-    # don't modify the parent context
-    if 'request' in context:
-        context = RequestContext(context['request'])
-    else:
-        context = Context()
     if isinstance(page, basestring):
         # add the slug separately because we need it in the template even
         # if this page doesn't exist
@@ -98,11 +81,6 @@ def page_content_teaser(context, page, num_words):
     """
     Renders a teaser of the given page object in the calling template.
     """
-    # don't modify the parent context
-    if 'request' in context:
-        context = RequestContext(context['request'])
-    else:
-        context = Context()
     if isinstance(page, basestring):
         # add the slug separately because we need it in the template even
         # if this page doesn't exist
@@ -134,11 +112,6 @@ def page_teaser(context, page, num_words):
     """
     Renders a better teaser of the given page object in the calling template.
     """
-    # don't modify the parent context
-    if 'request' in context:
-        context = RequestContext(context['request'])
-    else:
-        context = Context()
     if isinstance(page, basestring):
         # add the slug separately because we need it in the template even
         # if this page doesn't exist
@@ -178,13 +151,7 @@ def create_page(context, link_text):
     Renders a link to the admin to create a page based on the
     current request path. Meant to be used on a 404 page.
     """
-    # don't modify the parent context
-    if 'request' in context:
-        request = context['request']
-        context = RequestContext(request)
-    else:
-        return {'exists': True}
-
+    request = context['request']
     has_perm = request.user.has_perm('pagelets.add_page')
 
     if has_perm:

--- a/pagelets/tests/__init__.py
+++ b/pagelets/tests/__init__.py
@@ -1,1 +1,0 @@
-from .test_cases import *  # noqa

--- a/pagelets/tests/test_cases.py
+++ b/pagelets/tests/test_cases.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User, Permission
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 
+from pagelets.forms import PageForm
 from pagelets.models import Page, Pagelet
 
 
@@ -144,3 +145,11 @@ class PageTestCase(TestCase):
             test_page.full_clean()
         except ValidationError as e:
             self.fail(str(e))
+
+
+class PageFormTest(TestCase):
+
+    def test_form(self):
+        "Test that we can instantiate the form."
+        form = PageForm()
+        self.assertTrue(form)

--- a/pagelets/tests/urls.py
+++ b/pagelets/tests/urls.py
@@ -1,15 +1,10 @@
-try:
-    # Django 1.4+
-    from django.conf.urls import include, patterns, url
-except ImportError:
-    # Django 1.3
-    from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^pagelets/', include('pagelets.urls')),
     url(r'^admin/', include(admin.site.urls)),
-)
+]

--- a/pagelets/urls/__init__.py
+++ b/pagelets/urls/__init__.py
@@ -1,11 +1,6 @@
-try:
-    # Django 1.4+
-    from django.conf.urls import include, patterns, url
-except ImportError:
-    # Django 1.3
-    from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, url
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^management/', include('pagelets.urls.management')),
     url(r'^', include('pagelets.urls.content')),
-)
+]

--- a/pagelets/urls/content.py
+++ b/pagelets/urls/content.py
@@ -1,18 +1,13 @@
-try:
-    # Django 1.4+
-    from django.conf.urls import patterns, url
-except ImportError:
-    # Django 1.3
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import url
 
 from pagelets import views
 from pagelets.validators import PAGE_SLUG_RE
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(
         r'^(?P<page_slug>%s)/$' % PAGE_SLUG_RE,
         views.view_page,
         name='view_page',
     ),
-)
+]

--- a/pagelets/urls/management.py
+++ b/pagelets/urls/management.py
@@ -1,15 +1,10 @@
-try:
-    # Django 1.4+
-    from django.conf.urls import patterns, url
-except ImportError:
-    # Django 1.3
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import url
 
 from pagelets import views
 from pagelets.validators import PAGE_SLUG_RE
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(
         r'^pagelet/(?:(?P<pagelet_slug>[^/]+)/)?create/$',
         views.create_pagelet,
@@ -35,4 +30,4 @@ urlpatterns = patterns('',
         views.remove_attachment,
         name='remove_attachment',
     ),
-)
+]

--- a/pagelets/utils.py
+++ b/pagelets/utils.py
@@ -1,12 +1,6 @@
+from django.utils.text import Truncator
+
 
 def truncate_html_words(value, num_words):
-    """Backwords compatibility shim."""
-    try:
-        # Django 1.4+
-        from django.utils.text import Truncator
-    except ImportError:
-        # Django 1.3
-        from django.utils.text import truncate_html_words
-        return truncate_html_words(value, num_words)
-    else:
-        return Truncator(value).words(num_words, html=True)
+    """Truncate 'value' to num_words words, ignoring HTML tags."""
+    return Truncator(value).words(num_words, html=True)

--- a/pagelets/validators.py
+++ b/pagelets/validators.py
@@ -1,16 +1,16 @@
 import re
 from django.core.exceptions import ValidationError
-from django.core.validators import RegexValidator
 from django.utils.translation import gettext_lazy as _
 
 
 PAGE_SLUG_RE = r'[-\w/\.~]+'
 
+
 def validate_url_chars(value):
     if re.match(PAGE_SLUG_RE, value) is None:
         raise ValidationError(_(u"Enter a valid 'slug' consisting of valid url characters. "
-            u"These include uppercase and lowercase letters, decimal digits, "
-            u"hyphen, period, underscore, and tilde."), code= u'invalid')
+                                u"These include uppercase and lowercase letters, decimal digits, "
+                                u"hyphen, period, underscore, and tilde."), code=u'invalid')
 
 
 def validate_leading_slash(value):

--- a/pagelets/views.py
+++ b/pagelets/views.py
@@ -2,9 +2,7 @@ import hashlib
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
-from django.template import RequestContext
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import condition
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import user_passes_test
@@ -23,10 +21,10 @@ def view_page(request, page_slug, template='pagelets/view_page.html'):
     context = {
         'page': page,
     }
-    return render_to_response(
+    return render(
+        request,
         page.base_template or template,
         context,
-        context_instance=RequestContext(request),
     )
 
 
@@ -96,7 +94,7 @@ def edit_pagelet(
     redirect_field_name=REDIRECT_FIELD_NAME,
     redirect_to=None,
 ):
-    redirect_to = request.REQUEST.get(redirect_field_name, redirect_to)
+    redirect_to = request.GET.get(redirect_field_name, redirect_to)
     if not redirect_to:
         redirect_to = '/'
 
@@ -111,7 +109,7 @@ def edit_pagelet(
         if request.POST:
             form = PageletForm(request.POST, instance=pagelet)
             if form.is_valid():
-                if 'save_btn' in request.REQUEST:
+                if 'save_btn' in request.POST:
                     form.save(user=request.user)
                     return HttpResponseRedirect(redirect_to)
                 else:
@@ -131,10 +129,10 @@ def edit_pagelet(
             'pagelet_preview': pagelet_preview,
         }
 
-        return render_to_response(
+        return render(
+            request,
             template,
             context,
-            context_instance=RequestContext(request),
         )
     return _(request)
 
@@ -158,10 +156,10 @@ def remove_pagelet(
         pagelet.delete()
         messages.info(request, 'Pagelet successfully deleted.')
         return HttpResponseRedirect(redirect_to)
-    return render_to_response(
+    return render(
+        request,
         template,
         {'pagelet': pagelet},
-        context_instance=RequestContext(request),
     )
 
 
@@ -187,10 +185,10 @@ def add_attachment(
         'page': page,
         'form': form,
     }
-    return render_to_response(
+    return render(
+        request,
         template,
         context,
-        context_instance=RequestContext(request),
     )
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,12 +5,8 @@ import sys
 import optparse
 
 from django.conf import settings
-from django.core.management import call_command
-try:
-    from django import setup
-except ImportError:
-    def setup():
-        pass
+from django import setup
+from django.test.utils import get_runner
 
 parser = optparse.OptionParser()
 opts, args = parser.parse_args()
@@ -18,14 +14,7 @@ opts, args = parser.parse_args()
 directory = os.path.abspath('%s' % os.path.dirname(__file__))
 
 if not settings.configured:
-    jenkins = []
-    db_name = 'test_pagelets'
-    if 'jenkins' in args:
-        jenkins = ['django_jenkins']
-        db_name = "pagelets_%s" % os.environ.get('TESTENV', db_name)
-
     settings.configure(
-        AUTH_USER_MODEL='auth.User',
         DATABASES={
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
@@ -34,7 +23,6 @@ if not settings.configured:
                 'PASSWORD': '',
                 'HOST': '',
                 'PORT': '',
-                'TEST_NAME': db_name,
             }
         },
         INSTALLED_APPS=[
@@ -45,61 +33,35 @@ if not settings.configured:
             'django.contrib.sites',
             'django.contrib.messages',
             'django.contrib.staticfiles',
-            'django.contrib.webdesign',
             'pagelets',
             'selectable',
             'taggit',
-        ] + jenkins,
-        SITE_ID=1,
+        ],
         ROOT_URLCONF='pagelets.tests.urls',
         MIDDLEWARE_CLASSES=(
             'django.contrib.sessions.middleware.SessionMiddleware',
             'django.contrib.auth.middleware.AuthenticationMiddleware',
         ),
-        TEMPLATE_LOADERS=(
-            'django.template.loaders.app_directories.Loader',
-            'django.template.loaders.filesystem.Loader',
-        ),
-        TEMPLATE_CONTEXT_PROCESSORS=(
-            "django.contrib.auth.context_processors.auth",
-            "django.core.context_processors.debug",
-            "django.core.context_processors.i18n",
-            "django.core.context_processors.media",
-            "django.core.context_processors.static",
-            "django.contrib.messages.context_processors.messages",
-            'django.core.context_processors.request',
-        ),
-        TEMPLATE_DIRS=(
-            '%s/sample_project/templates' % directory,
-        ),
-        PASSWORD_HASHERS=['django.contrib.auth.hashers.MD5PasswordHasher'],  # Increase speed in 1.4
-        PROJECT_APPS=('pagelets',),
-        JENKINS_TASKS=(
-            'django_jenkins.tasks.with_coverage',
-            'django_jenkins.tasks.django_tests',
-            'django_jenkins.tasks.run_pep8',
-        ),
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': ['%s/sample_project/templates' % directory],
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'context_processors': [
+                        "django.contrib.auth.context_processors.auth",
+                        "django.template.context_processors.debug",
+                        "django.template.context_processors.i18n",
+                        "django.template.context_processors.media",
+                        "django.template.context_processors.static",
+                        "django.contrib.messages.context_processors.messages",
+                        'django.template.context_processors.request',
+                    ]
+                },
+            },
+        ],
+        STATIC_URL='/static/',
     )
-
-
-def run_jenkins_tests():
-    kwargs = {
-        'pep8-exclude': 'migrations',
-        'pep8-select': '',
-        'pep8-ignore': '',
-        'pep8-max-line-length': 80,
-        'coverage-exclude': 'pagelets.migrations',
-        'coverage_with_migrations': False,
-        'coverage_html_report_dir': '',
-        'coverage_excludes': [],
-        'coverage_measure_branch': False,
-        'coverage_rcfile': '',
-        'output_dir': 'reports/',
-    }
-    call_command('jenkins', **kwargs)
-
-
-from django.test.utils import get_runner
 
 
 def run_django_tests():
@@ -111,10 +73,8 @@ def run_django_tests():
 
 def run():
     setup()
-    if 'jenkins' in args:
-        run_jenkins_tests()
-    else:
-        run_django_tests()
+    run_django_tests()
+
 
 if __name__ == '__main__':
     run()

--- a/sample_project/hudson_test_settings.py
+++ b/sample_project/hudson_test_settings.py
@@ -12,7 +12,6 @@ DATABASES = {
 }
 
 INSTALLED_APPS = list(INSTALLED_APPS)
-# disable south
-INSTALLED_APPS.remove('south')
+INSTALLED_APPS.append('django_jenkins')
 
 PROJECT_APPS = ('pagelets',)

--- a/sample_project/hudson_test_settings.py
+++ b/sample_project/hudson_test_settings.py
@@ -13,8 +13,6 @@ DATABASES = {
 
 INSTALLED_APPS = list(INSTALLED_APPS)
 # disable south
-# there seems to be an issue with south + django_jenkins
 INSTALLED_APPS.remove('south')
-INSTALLED_APPS.append('django_jenkins')
 
 PROJECT_APPS = ('pagelets',)

--- a/sample_project/requirements.txt
+++ b/sample_project/requirements.txt
@@ -1,2 +1,4 @@
-Django==1.6.2
-South==0.8.4
+Django==1.8
+django-taggit==0.21.3
+django-selectable==0.9.0
+markdown==2.6

--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -117,7 +117,6 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.webdesign',
     # Uncomment the next line to enable the admin:
     'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:

--- a/sample_project/settings.py
+++ b/sample_project/settings.py
@@ -1,13 +1,10 @@
 # Django settings for sample_project project.
 import os.path
 import sys
-if 'test' in sys.argv:
-    SOUTH_TESTS_MIGRATE = False
 AUTH_USER_MODEL = 'auth.User'
 PROJECT_PATH = os.path.abspath('%s' % os.path.dirname(__file__))
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -25,6 +22,30 @@ DATABASES = {
         'PORT': '',                      # Set to empty string for default. Not used with sqlite3.
     }
 }
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': (
+            # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
+            # Always use forward slashes, even on Windows.
+            # Don't forget to use absolute paths, not relative paths.
+            '%s/templates' % PROJECT_PATH,
+        ),
+        'OPTIONS': {
+            'context_processors': (
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.contrib.messages.context_processors.messages",
+                'django.template.context_processors.request',
+            )
+        }
+    }
+]
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -51,12 +72,12 @@ USE_L10N = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
-MEDIA_ROOT = ''
+MEDIA_ROOT = 'media'
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
-MEDIA_URL = ''
+MEDIA_URL = '/media/'
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -76,13 +97,6 @@ ADMIN_MEDIA_PREFIX = '/static/admin/'
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'INSECURE SECREY_KEY CHANGE ME'
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-#     'django.template.loaders.eggs.Loader',
-)
-
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -92,23 +106,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 ROOT_URLCONF = 'sample_project.urls'
-
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    '%s/templates' % PROJECT_PATH,
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static",
-    "django.contrib.messages.context_processors.messages",
-    'django.core.context_processors.request',
-)
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -121,6 +118,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
+    'taggit',
+    'selectable',
     'pagelets',
-    'south',
 )

--- a/sample_project/urls.py
+++ b/sample_project/urls.py
@@ -1,7 +1,8 @@
 import os
 
 from django.conf import settings
-from django.conf.urls.defaults import *
+from django.conf.urls import url, include
+from django.conf.urls.static import static
 from django.contrib import admin
 
 from pagelets.sitemaps import PageSiteMap
@@ -13,9 +14,10 @@ sitemaps = {
 }
 
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-    (r'^pagelets-management/', include('pagelets.urls.management')),
-    (r'^cms/', include('pagelets.urls.content')),
-    (r'^sitemap\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': sitemaps}),
-)
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^pagelets-management/', include('pagelets.urls.management')),
+    url(r'^cms/', include('pagelets.urls.content')),
+    url(r'^sitemap\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': sitemaps}),
+    url(r'^selectable/', include('selectable.urls')),
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+exclude = migrations,docs,env,.tox,sample_project
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,16 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Operating System :: OS Independent',
     ],
     long_description=open('README.rst').read(),
-    zip_safe=False, # because we're including media that Django needs
+    zip_safe=False,  # because we're including media that Django needs
+    install_requires=[
+        "django-selectable>=0.9.0",
+        "django-taggit>=0.12.1",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,33 @@
 [tox]
-envlist =
-    py27-1.7,
-    py33-1.7
-
-[default]
-deps =
-    django-jenkins==0.12.1
-    pylint==0.25.1
-    coverage==3.5.2
-    pep8==0.6.1
-    psycopg2==2.4.1
-    django-taggit==0.12.1
-    django-selectable==0.9.0
+envlist = {py27,py34,py35}-{dj1.8,dj1.9,dj1.10},py33-dj1.8,flake8,coverage,docs
 
 [testenv]
-setenv =
-    PYTHON_PATH = {toxinidir}
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+deps =
+    dj1.8: Django>=1.8,<1.9
+    dj1.9: Django>=1.9,<1.10
+    dj1.10: Django>=1.10,<1.11
 commands = {envpython} run_tests.py {posargs}
 
-[testenv:py27-1.7]
-setenv =
-    {[testenv]setenv}
-    TESTENV = py27-1.7
-deps =
-    django>=1.7,<1.8
-    {[default]deps}
+[testenv:flake8]
+basepython = python3.5
+commands = flake8 .
+deps = flake8>=2.2.2
 
-[testenv:py33-1.7]
-basepython = python3.3
-setenv =
-    {[testenv]setenv}
-    TESTENV = py33-1.7
+[testenv:coverage]
+basepython = python3.5
+commands =
+    coverage run run_tests.py
+    coverage report -m --fail-under 60
 deps =
-    django>=1.7,<1.8
-    django-taggit==0.12.1
-    django-selectable==0.9.0
+    Django>=1.8,<1.9
+    coverage>=3.7.1
+
+[testenv:docs]
+basepython = python2.7
+deps = Sphinx==1.2.2
+commands = {envbindir}/sphinx-build -a -n -b html -d docs/_build/doctrees docs docs/_build/html


### PR DESCRIPTION
There are a lot of little changes, so I tried to group the less controversial ones in the first commit, and the ones that might need a bit more review in the second commit.

This:
* drops support for Django 1.7
* adds support for Django 1.8, 1.9, and 1.10
* expands the tox file to generate more possible combinations
* Adds Travis CI configuration
* Adds flake8 and coverage
* removes unused django-jenkins support
* bumps the version to 1.0.0 (once this is released)